### PR TITLE
Fixed false positive on HighCPS and AutoClicker

### DIFF
--- a/src/xyz/msws/nope/checks/combat/AutoClicker1.java
+++ b/src/xyz/msws/nope/checks/combat/AutoClicker1.java
@@ -69,7 +69,9 @@ public class AutoClicker1 implements Check, Listener {
 		if (event.getAction() == Action.LEFT_CLICK_BLOCK)
 			return;
 
-		if (block != null && (!block.getType().isSolid() || block.getType() == Material.SLIME_BLOCK))
+		if (block != null && (!block.getType().isSolid()
+				|| block.getType() == Material.SLIME_BLOCK
+				|| block.getType() == Material.REDSTONE_ORE)) // redstone ore triggers a false positive
 			return;
 
 		List<Double> clickTimings = timings.getOrDefault(player.getUniqueId(), new ArrayList<>());

--- a/src/xyz/msws/nope/checks/combat/HighCPS1.java
+++ b/src/xyz/msws/nope/checks/combat/HighCPS1.java
@@ -72,7 +72,9 @@ public class HighCPS1 implements Check, Listener {
 		if (event.getAction() == Action.LEFT_CLICK_BLOCK)
 			return;
 
-		if (block != null && (!block.getType().isSolid() || block.getType() == Material.SLIME_BLOCK))
+		if (block != null && (!block.getType().isSolid()
+				|| block.getType() == Material.SLIME_BLOCK
+				|| block.getType() == Material.REDSTONE_ORE)) // redstone ore triggers a false positive
 			return;
 
 		int c = clicks.getOrDefault(player.getUniqueId(), 0);

--- a/src/xyz/msws/nope/checks/combat/HighCPS2.java
+++ b/src/xyz/msws/nope/checks/combat/HighCPS2.java
@@ -71,7 +71,9 @@ public class HighCPS2 implements Check, Listener {
 		if (event.getAction() == Action.LEFT_CLICK_BLOCK)
 			return;
 
-		if (block != null && (!block.getType().isSolid() || block.getType() == Material.SLIME_BLOCK))
+		if (block != null && (!block.getType().isSolid()
+				|| block.getType() == Material.SLIME_BLOCK
+				|| block.getType() == Material.REDSTONE_ORE)) // redstone ore triggers a false positive
 			return;
 
 		int c = clicks.getOrDefault(player.getUniqueId(), 0);

--- a/src/xyz/msws/nope/checks/combat/HighCPS3.java
+++ b/src/xyz/msws/nope/checks/combat/HighCPS3.java
@@ -72,7 +72,9 @@ public class HighCPS3 implements Check, Listener {
 		if (event.getAction() == Action.LEFT_CLICK_BLOCK)
 			return;
 
-		if (block != null && (!block.getType().isSolid() || block.getType() == Material.SLIME_BLOCK))
+		if (block != null && (!block.getType().isSolid()
+				|| block.getType() == Material.SLIME_BLOCK
+				|| block.getType() == Material.REDSTONE_ORE)) // redstone ore triggers a false positive
 			return;
 
 		int c = clicks.getOrDefault(player.getUniqueId(), 0);


### PR DESCRIPTION
Redstone ore triggers a false positive for HighCPS and AutoClicker when a player stands on it.
This pull request adds an exception for redstone ore on HighCPS#1, HighCPS#2, HighCPS#3, and AutoClicker#1.
